### PR TITLE
Implement signup with auth context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,23 +6,26 @@ import { Route, Routes } from "react-router-dom";
 import LoginPage from "./pages/LoginPage";
 import { PhotobookEditorMock } from "./components/PhotobookEditorMock";
 import { CartProvider } from "./Cart/CartProvider";
+import { AuthProvider } from "./Auth/AuthContext";
 import CartPage from "./pages/CartPage";
 
 function App() {
   return (
     <div className="flex flex-col min-h-screen bg-background text-text-primary">
-      <CartProvider>
-        <Header />
-        <main className="flex-grow">
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/editor" element={<PhotobookEditorMock />} />
-            <Route path="/cart" element={<CartPage />} />
-            <Route path="/login" element={<LoginPage />} />
-          </Routes>
-        </main>
-        <Footer />
-      </CartProvider>
+      <AuthProvider>
+        <CartProvider>
+          <Header />
+          <main className="flex-grow">
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/editor" element={<PhotobookEditorMock />} />
+              <Route path="/cart" element={<CartPage />} />
+              <Route path="/login" element={<LoginPage />} />
+            </Routes>
+          </main>
+          <Footer />
+        </CartProvider>
+      </AuthProvider>
     </div>
   );
 }

--- a/src/Auth/AuthContext.tsx
+++ b/src/Auth/AuthContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import {
+  User,
+  onAuthStateChanged,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  signOut as firebaseSignOut,
+} from "firebase/auth";
+import { auth } from "../firebase/firebase";
+
+interface AuthContextValue {
+  user: User | null;
+  signUp: (email: string, password: string) => Promise<User>;
+  signIn: (email: string, password: string) => Promise<User>;
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+      setUser(firebaseUser);
+    });
+    return unsubscribe;
+  }, []);
+
+  const signUp = async (email: string, password: string) => {
+    const cred = await createUserWithEmailAndPassword(auth, email, password);
+    return cred.user;
+  };
+
+  const signIn = async (email: string, password: string) => {
+    const cred = await signInWithEmailAndPassword(auth, email, password);
+    return cred.user;
+  };
+
+  const signOut = async () => {
+    await firebaseSignOut(auth);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, signUp, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};
+

--- a/src/Auth/LoginButton.tsx
+++ b/src/Auth/LoginButton.tsx
@@ -1,7 +1,26 @@
-import { Link } from "react-router-dom";
-import { LogIn } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
+import { LogIn, LogOut } from "lucide-react";
+import { useAuth } from "./AuthContext";
 
 export const LoginButton = () => {
+  const { user, signOut } = useAuth();
+  const navigate = useNavigate();
+
+  if (user) {
+    return (
+      <button
+        onClick={async () => {
+          await signOut();
+          navigate("/");
+        }}
+        className="flex items-center text-text-secondary hover:text-accent-bluegray"
+      >
+        <LogOut className="w-5 h-5 mr-1" />
+        <span>Logout</span>
+      </button>
+    );
+  }
+
   return (
     <Link
       to="/login"

--- a/src/Auth/SignIn.tsx
+++ b/src/Auth/SignIn.tsx
@@ -1,24 +1,22 @@
 import React, { useState } from "react";
-import { signInWithEmailAndPassword } from "firebase/auth";
-import { auth } from "../firebase/firebase";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "./AuthContext";
 
 const SignIn: React.FC = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const { signIn } = useAuth();
+  const navigate = useNavigate();
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const userCredential = await signInWithEmailAndPassword(
-        auth,
-        email,
-        password
-      );
-      // Signed in successfully
-      const user = userCredential.user;
-      console.log("User signed in:", user);
-    } catch (error) {
-      console.error("Error signing in:", error);
+      setError(null);
+      await signIn(email, password);
+      navigate("/");
+    } catch (err) {
+      setError((err as Error).message);
     }
   };
 
@@ -38,6 +36,7 @@ const SignIn: React.FC = () => {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
       <button type="submit" className="bg-green-500 text-white p-2 rounded">
         Sign In
       </button>

--- a/src/Auth/SignUp.tsx
+++ b/src/Auth/SignUp.tsx
@@ -1,24 +1,22 @@
 import React, { useState } from "react";
-import { createUserWithEmailAndPassword } from "firebase/auth";
-import { auth } from "../firebase/firebase";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "./AuthContext";
 
 const SignUp: React.FC = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const { signUp } = useAuth();
+  const navigate = useNavigate();
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const userCredential = await createUserWithEmailAndPassword(
-        auth,
-        email,
-        password
-      );
-      // Signed up successfully
-      const user = userCredential.user;
-      console.log("User signed up:", user);
-    } catch (error) {
-      console.error("Error signing up:", error);
+      setError(null);
+      await signUp(email, password);
+      navigate("/");
+    } catch (err) {
+      setError((err as Error).message);
     }
   };
 
@@ -38,6 +36,7 @@ const SignUp: React.FC = () => {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
       <button type="submit" className="bg-blue-500 text-white p-2 rounded">
         Sign Up
       </button>

--- a/src/Layout/Header.tsx
+++ b/src/Layout/Header.tsx
@@ -1,8 +1,11 @@
 import { Link } from "react-router-dom";
 import { CartButton } from "../Cart/CartButton";
 import { LoginButton } from "../Auth/LoginButton";
+import { useAuth } from "../Auth/AuthContext";
 
 const Header = () => {
+  const { user } = useAuth();
+
   return (
     <header className="bg-topbar shadow-md">
       <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
@@ -10,6 +13,7 @@ const Header = () => {
           Photobook
         </Link>
         <div className="ml-auto flex items-center space-x-6">
+          {user && <span className="text-text-secondary">{user.email}</span>}
           <CartButton />
           <LoginButton />
         </div>


### PR DESCRIPTION
## Summary
- add new `AuthProvider` with signUp/signIn/signOut helpers
- use context in SignUp and SignIn forms and navigate on success
- show Logout button when authenticated
- wrap app with `AuthProvider`

## Testing
- `npm run lint -- --fix`

------
https://chatgpt.com/codex/tasks/task_e_684566016428832eb8a18242211d4ccb