### PR TITLE
Integrate shadcn/ui styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,19 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
+        "@radix-ui/react-slot": "^1.2.3",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.21",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "eslint": "^9.21.0",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.15.0",
+        "tailwind-merge": "^3.3.0",
+        "tailwindcss-animate": "^1.0.7",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.24.1",
         "vite": "^6.2.0"
@@ -1868,6 +1873,41 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
@@ -3127,6 +3167,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3139,6 +3192,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -5816,11 +5879,32 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
+      "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
       "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
       "license": "MIT"
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
     },
     "node_modules/tapable": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "fabric": "^6.7.0",
     "firebase": "^11.6.1",
     "lucide-react": "^0.509.0",
@@ -18,6 +21,7 @@
     "react-dom": "^19.0.0",
     "react-router": "^7.5.2",
     "react-router-dom": "^7.5.2",
+    "tailwind-merge": "^3.3.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
@@ -30,6 +34,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
+    "tailwindcss-animate": "^1.0.7",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0"

--- a/src/Auth/SignIn.tsx
+++ b/src/Auth/SignIn.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "./AuthContext";
+import { Input } from "../components/ui/input";
+import { Button } from "../components/ui/button";
 
 const SignIn: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -22,24 +24,22 @@ const SignIn: React.FC = () => {
 
   return (
     <form onSubmit={handleSignIn} className="flex flex-col space-y-4">
-      <input
+      <Input
         type="email"
         placeholder="Email"
-        className="p-2 border border-gray-300 rounded"
         value={email}
         onChange={(e) => setEmail(e.target.value)}
       />
-      <input
+      <Input
         type="password"
         placeholder="Password"
-        className="p-2 border border-gray-300 rounded"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
       {error && <p className="text-red-500 text-sm">{error}</p>}
-      <button type="submit" className="bg-green-500 text-white p-2 rounded">
+      <Button type="submit" className="bg-green-500 hover:bg-green-600">
         Sign In
-      </button>
+      </Button>
     </form>
   );
 };

--- a/src/Auth/SignUp.tsx
+++ b/src/Auth/SignUp.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "./AuthContext";
+import { Input } from "../components/ui/input";
+import { Button } from "../components/ui/button";
 
 const SignUp: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -22,24 +24,22 @@ const SignUp: React.FC = () => {
 
   return (
     <form onSubmit={handleSignUp} className="flex flex-col space-y-4">
-      <input
+      <Input
         type="email"
         placeholder="Email"
-        className="p-2 border border-gray-300 rounded"
         value={email}
         onChange={(e) => setEmail(e.target.value)}
       />
-      <input
+      <Input
         type="password"
         placeholder="Password"
-        className="p-2 border border-gray-300 rounded"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
       {error && <p className="text-red-500 text-sm">{error}</p>}
-      <button type="submit" className="bg-blue-500 text-white p-2 rounded">
+      <Button type="submit" className="bg-blue-500 hover:bg-blue-600">
         Sign Up
-      </button>
+      </Button>
     </form>
   );
 };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "../../lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-accent-bluegray text-white hover:bg-accent-bluegray/90",
+        destructive:
+          "bg-red-500 text-white hover:bg-red-600",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "underline-offset-4 hover:underline text-primary",
+      },
+      size: {
+        default: "h-10 py-2 px-4",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,50 @@
+import * as React from "react"
+import { cn } from "../../lib/utils"
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-surface text-text-primary shadow-sm", className)}
+      {...props}
+    />
+  )
+)
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+)
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("text-2xl font-semibold leading-none", className)} {...props} />
+  )
+)
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-text-secondary", className)} {...props} />
+  )
+)
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+)
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+)
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { cn } from "../../lib/utils"
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -1,12 +1,15 @@
 import { useCart } from "../Cart/useCart";
 import PageLayout from "../Layout/PageLayout";
+import { Card, CardContent } from "../components/ui/card";
+import { Button } from "../components/ui/button";
 
 const CartPage = () => {
   const { state, dispatch } = useCart();
 
   return (
     <PageLayout title="Cart">
-      <div className="mt-6 tablet:mt-8 desktop:mt-10 max-w-sm tablet:max-w-md desktop:max-w-lg w-full bg-white shadow-lg rounded-lg p-4">
+      <Card className="mt-6 tablet:mt-8 desktop:mt-10 max-w-sm tablet:max-w-md desktop:max-w-lg w-full">
+        <CardContent className="p-4">
         {state.items.length === 0 ? (
           <p className="text-gray-500">Your cart is empty.</p>
         ) : (
@@ -20,27 +23,29 @@ const CartPage = () => {
                   <p className="font-medium">{item.name}</p>
                   <p className="text-sm text-gray-600">{`$${item.price.toFixed(2)}`}</p>
                 </div>
-                <button
+                <Button
+                  variant="destructive"
+                  size="sm"
                   onClick={() => dispatch({ type: "REMOVE_ITEM", payload: item.id })}
-                  className="text-red-500 hover:text-red-700 text-sm"
                 >
                   Remove
-                </button>
+                </Button>
               </li>
             ))}
           </ul>
         )}
         {state.items.length > 0 && (
-          <button
-            className="mt-4 w-full bg-green-600 text-white py-2 rounded-xl hover:bg-green-700 transition"
+          <Button
+            className="mt-4 w-full bg-green-600 hover:bg-green-700"
             onClick={() => {
               /*todo: navigate to checkout*/
             }}
           >
             Proceed to Checkout
-          </button>
+          </Button>
         )}
-      </div>
+        </CardContent>
+      </Card>
     </PageLayout>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import hardCoverPhoto from "../assets/hard-cover-photo-books_2.jpeg";
 import PageLayout from "../Layout/PageLayout";
+import { Card, CardContent, CardTitle, CardDescription } from "../components/ui/card";
 
 const Home = () => {
   const navigate = useNavigate();
@@ -12,22 +13,20 @@ const Home = () => {
   return (
     <PageLayout title="Choose Your Photobook">
       <div className="grid grid-cols-1 sm:grid-cols-2 tablet:grid-cols-3 desktop:grid-cols-4 gap-6">
-        <div
-          className="bg-surface rounded-lg p-4 shadow-md hover:shadow-lg transform hover:-translate-y-1 transition duration-300 cursor-pointer"
+        <Card
+          className="hover:shadow-lg transform hover:-translate-y-1 transition duration-300 cursor-pointer"
           onClick={handleCardSelect}
         >
           <img
             src={hardCoverPhoto}
             alt="Card Preview"
-            className="w-full h-48 object-cover mb-4 rounded"
+            className="w-full h-48 object-cover rounded-t-lg"
           />
-          <h2 className="text-xl font-semibold text-text-primary">
-            Classic Layout
-          </h2>
-          <p className="text-text-secondary">
-            A timeless design for your memories.
-          </p>
-        </div>
+          <CardContent>
+            <CardTitle>Classic Layout</CardTitle>
+            <CardDescription>A timeless design for your memories.</CardDescription>
+          </CardContent>
+        </Card>
         {/* Add more cards as needed */}
       </div>
     </PageLayout>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import SignIn from "../Auth/SignIn";
 import SignUp from "../Auth/SignUp";
 import PageLayout from "../Layout/PageLayout";
+import { Card, CardContent } from "../components/ui/card";
 const LoginPage: React.FC = () => {
   const [isSignIn, setIsSignIn] = useState(true);
 
@@ -10,18 +11,20 @@ const LoginPage: React.FC = () => {
       title={isSignIn ? "Sign In to Photobook" : "Create a Photobook Account"}
     >
       <div className="flex flex-col items-center bg-gray-100">
-        <div className="bg-white p-4 tablet:p-8 rounded shadow-md w-full max-w-sm tablet:max-w-md">
-          {isSignIn ? <SignIn /> : <SignUp />}
-          <p className="mt-4 text-center text-sm text-gray-600">
-            {isSignIn ? "Don't have an account?" : "Already have an account?"}{" "}
-            <button
-              onClick={() => setIsSignIn(!isSignIn)}
-              className="text-blue-500 hover:underline"
-            >
-              {isSignIn ? "Sign Up" : "Sign In"}
-            </button>
-          </p>
-        </div>
+        <Card className="w-full max-w-sm tablet:max-w-md">
+          <CardContent className="p-4 tablet:p-8">
+            {isSignIn ? <SignIn /> : <SignUp />}
+            <p className="mt-4 text-center text-sm text-gray-600">
+              {isSignIn ? "Don't have an account?" : "Already have an account?"}{" "}
+              <button
+                onClick={() => setIsSignIn(!isSignIn)}
+                className="text-blue-500 hover:underline"
+              >
+                {isSignIn ? "Sign Up" : "Sign In"}
+              </button>
+            </p>
+          </CardContent>
+        </Card>
       </div>
     </PageLayout>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,5 +16,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('tailwindcss-animate')],
 };


### PR DESCRIPTION
## Summary
- add shadcn/ui packages
- configure Tailwind for shadcn plugins
- create reusable Button, Input and Card components
- restyle forms and pages to use these components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845f27b2d44832ebbaaad56da21cd08