### PR TITLE
feat: add sidebar for cart and login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from "./Auth/AuthContext";
 import CartPage from "./pages/CartPage";
 import MainContent from "./Layout/MainContent";
 import EditorPage from "./pages/EditorPage";
+import Sidebar from "./Layout/Sidebar";
 
 function App() {
   return (
@@ -15,14 +16,17 @@ function App() {
       <AuthProvider>
         <CartProvider>
           <Header />
-          <MainContent>
-            <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/editor" element={<EditorPage />} />
-              <Route path="/cart" element={<CartPage />} />
-              <Route path="/login" element={<LoginPage />} />
-            </Routes>
-          </MainContent>
+          <div className="flex flex-1">
+            <Sidebar />
+            <MainContent>
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/editor" element={<EditorPage />} />
+                <Route path="/cart" element={<CartPage />} />
+                <Route path="/login" element={<LoginPage />} />
+              </Routes>
+            </MainContent>
+          </div>
           <Footer />
         </CartProvider>
       </AuthProvider>

--- a/src/Layout/Header.tsx
+++ b/src/Layout/Header.tsx
@@ -1,83 +1,12 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
-import { Menu, X } from "lucide-react";
-import { CartButton } from "../Cart/CartButton";
-import { LoginButton } from "../Auth/LoginButton";
-import { useAuth } from "../Auth/AuthContext";
-
-//todo: Enable in case we want to add more links
-// const links = [
-//   { label: "Home", to: "/" },
-//   { label: "Create", to: "/editor" },
-// ];
 
 const Header = () => {
-  const { user } = useAuth();
-  const [mobileOpen, setMobileOpen] = useState(false);
-
   return (
     <header className="bg-topbar shadow-md">
-      <div className="max-w-7xl mx-auto px-4 py-2 tablet:py-4 flex items-center relative">
+      <div className="max-w-7xl mx-auto px-4 py-2 tablet:py-4 flex items-center">
         <Link to="/" className="text-xl font-bold text-accent-bluegray">
           Photobook
         </Link>
-        <div className="ml-auto flex items-center">
-          <CartButton />
-          {/* Show menu items inline on desktop (md and up) */}
-          <nav className="hidden md:flex items-center space-x-4 md:space-x-6 ml-4">
-            {/* {links.map(({ to, label }) => (
-              <Link key={to} to={to} className="hover:text-accent-bluegray">
-                {label}
-              </Link>
-            ))} */}
-            {user && (
-              <span
-                className="max-w-[9rem] truncate text-text-secondary"
-                title={user.email || undefined}
-              >
-                {user.email}
-              </span>
-            )}
-            <LoginButton />
-          </nav>
-          {/* Burger menu icon on mobile only */}
-          <button
-            className="ml-2 md:hidden p-2 text-text-secondary"
-            onClick={() => setMobileOpen(!mobileOpen)}
-            aria-label="Toggle menu"
-          >
-            {mobileOpen ? (
-              <X className="w-6 h-6" />
-            ) : (
-              <Menu className="w-6 h-6" />
-            )}
-          </button>
-        </div>
-
-        {/* Mobile menu dropdown */}
-        {mobileOpen && (
-          <div className="absolute right-4 top-full mt-2 w-40 bg-surface shadow-lg rounded p-4 flex flex-col space-y-3 md:hidden">
-            {/* {links.map(({ to, label }) => (
-              <Link
-                key={to}
-                to={to}
-                onClick={() => setMobileOpen(false)}
-                className="hover:text-accent-bluegray"
-              >
-                {label}
-              </Link>
-            ))} */}
-            {user && (
-              <span
-                className="text-text-secondary truncate"
-                title={user.email || undefined}
-              >
-                {user.email}
-              </span>
-            )}
-            <LoginButton onClick={() => setMobileOpen(false)} />
-          </div>
-        )}
       </div>
     </header>
   );

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { CartButton } from "../Cart/CartButton";
+import { LoginButton } from "../Auth/LoginButton";
+import { useAuth } from "../Auth/AuthContext";
+
+const Sidebar: React.FC = () => {
+  const { user } = useAuth();
+
+  return (
+    <aside className="w-48 bg-surface p-4 flex flex-col space-y-4">
+      <CartButton />
+      {user && (
+        <span
+          className="text-sm text-text-secondary break-all"
+          title={user.email || undefined}
+        >
+          {user.email}
+        </span>
+      )}
+      <LoginButton />
+    </aside>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
## Summary
- add sidebar to display cart and login controls
- remove cart/login from header and simplify header layout
- integrate sidebar into main layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68930aaf06a4832e9d5ef7f370abb0f0